### PR TITLE
Use tempfile crate instead of tempdir

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 cli-xtask = { path = "../", default-features = false, features = ["main", "lib-crate-extra", "subcommand-exec"] }
 dir-diff = "0.3.2"
-tempdir = "0.3.7"
+tempfile = "3.3.0"

--- a/xtask/src/lint_doc.rs
+++ b/xtask/src/lint_doc.rs
@@ -1,4 +1,4 @@
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 use cli_xtask::{
     camino::Utf8Path, clap, config::Config, eyre::eyre, tracing, workspace, Error, Result,
@@ -18,7 +18,7 @@ impl LintDoc {
         let workspace = workspace::current();
         let doc_dir = workspace.workspace_root.join("doc");
 
-        let reference_dir = TempDir::new("reference")?;
+        let reference_dir = TempDir::new()?;
         super::tidy_doc::emit_doc(workspace, <&Utf8Path>::try_from(reference_dir.path())?)?;
 
         if dir_diff::is_different(&doc_dir, &reference_dir).map_err(|e| -> Error {


### PR DESCRIPTION
tempdir is deprecated

fixes #23

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cli-xtask/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cli-xtask/blob/HEAD/CHANGELOG.md
-->
