### PR TITLE
man: handle spaces in command name

### DIFF
--- a/src/subcommand/dist_build_man.rs
+++ b/src/subcommand/dist_build_man.rs
@@ -75,7 +75,7 @@ fn dist_build_man_pages<'a>(
     );
     let source = format!(
         "{} {}",
-        cmd.get_name(),
+        cmd.get_name().replace(' ', "-"),
         cmd.get_version()
             .or_else(|| cmd.get_long_version())
             .unwrap_or_default()
@@ -83,7 +83,7 @@ fn dist_build_man_pages<'a>(
 
     let man_dir = man_dir.to_owned();
     let it = iterate_commands(cmd).map(move |cmd| {
-        let command_name = cmd.get_name().to_string();
+        let command_name = cmd.get_name().replace(' ', "-");
         let filename = format!("{command_name}.{}", section);
         let path = man_dir.join(&filename);
         let man = Man::new(cmd.clone())
@@ -112,7 +112,7 @@ fn iterate_commands<'a>(
         subcommands
             .into_iter()
             .map(move |mut subcommand| {
-                let name = format!("{command_name}-{}", subcommand.get_name());
+                let name = format!("{command_name} {}", subcommand.get_name());
                 subcommand = subcommand.name(name);
                 if subcommand.get_version().is_none() {
                     if let Some(version) = command_version {


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cli-xtask/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cli-xtask/blob/HEAD/CHANGELOG.md
-->
