### PR TITLE
dist: fix windows build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+* `xtask dist`: windows build now works again (binary name was wrong)
+
 ## [0.1.3] - 2022-09-06
+
+* `xtask docsrs`: change rustdoc parameters to support hosting on GitHub Pages
 
 ## [0.1.2] - 2022-09-05
 
+### Changed
+
+* `xtask docsrs`: generate `index.html` to redirect root package's documentation
+
 ## [0.1.1] - 2022-09-04
+
+### Fixed
+
+* `xtask man`: handle spaces in command name correctly
 
 ## [0.1.0] - 2022-08-25
 

--- a/src/subcommand/dist_build_bin.rs
+++ b/src/subcommand/dist_build_bin.rs
@@ -56,7 +56,7 @@ impl DistBuildBin {
                 )?;
                 for src in artifacts {
                     let src = src?;
-                    let dest = bin_dir.join(target.name());
+                    let dest = bin_dir.join(src.file_name().unwrap());
                     crate::fs::copy(&src, &dest)?;
                 }
             }


### PR DESCRIPTION
binary name was wrong

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cli-xtask/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cli-xtask/blob/HEAD/CHANGELOG.md
-->
