### PR TITLE
Revert "Removed a wrong default implementation of `Run::to_subcommand…

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -71,7 +71,7 @@ mod main;
 /// use cli_xtask::{
 ///     clap::{self, Parser},
 ///     config::Config,
-///     subcommand, Result, Run, SubcommandRun, Xtask,
+///     subcommand, Result, Run, Xtask,
 /// };
 ///
 /// // Define your own subcommand arguments
@@ -93,10 +93,6 @@ mod main;
 ///             Self::Bar => println!("bar!"),
 ///         }
 ///         Ok(())
-///     }
-///
-///     fn to_subcommands(&self) -> Option<SubcommandRun> {
-///         None
 ///     }
 ///
 ///     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,9 @@ pub trait Run: Any {
     fn run(&self, config: &config::Config) -> Result<()>;
 
     /// Returns the subcommands that this command will run.
-    fn to_subcommands(&self) -> Option<SubcommandRun>;
+    fn to_subcommands(&self) -> Option<SubcommandRun> {
+        None
+    }
 
     /// Converts the `Box<dyn Run>` to `Box<dyn Any>`.
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
@@ -340,10 +342,6 @@ mod tests {
     impl Run for S {
         fn run(&self, _config: &config::Config) -> Result<()> {
             Ok(())
-        }
-
-        fn to_subcommands(&self) -> Option<SubcommandRun> {
-            None
         }
 
         fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -2,7 +2,7 @@
 
 use std::any::Any;
 
-use crate::{config::Config, Result, Run, SubcommandRun};
+use crate::{config::Config, Result, Run};
 
 #[cfg(feature = "subcommand-build")]
 #[cfg_attr(docsrs, doc(cfg(feature = "subcommand-build")))]
@@ -323,10 +323,6 @@ pub enum Subcommand {
 impl Run for Subcommand {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/build.rs
+++ b/src/subcommand/build.rs
@@ -4,7 +4,7 @@ use crate::{
     args::{EnvArgs, FeatureArgs},
     config::Config,
     process::CommandExt,
-    Result, Run, SubcommandRun,
+    Result, Run,
 };
 
 /// Arguments definition of the `build` subcommand.
@@ -25,10 +25,6 @@ pub struct Build {
 impl Run for Build {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/clippy.rs
+++ b/src/subcommand/clippy.rs
@@ -4,7 +4,7 @@ use crate::{
     args::{EnvArgs, FeatureArgs},
     config::Config,
     process::CommandExt,
-    Result, Run, SubcommandRun,
+    Result, Run,
 };
 
 /// Arguments definition of the `clippy` subcommand.
@@ -25,10 +25,6 @@ pub struct Clippy {
 impl Run for Clippy {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist.rs
+++ b/src/subcommand/dist.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::{config::Config, Result, Run, SubcommandRun};
+use crate::{config::Config, Result, Run};
 
 /// Arguments definition of the `dist` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist.md"))]
@@ -20,10 +20,6 @@ pub struct Dist {
 impl Run for Dist {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist_archive.rs
+++ b/src/subcommand/dist_archive.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::{archive, config::Config, Result, Run, SubcommandRun};
+use crate::{archive, config::Config, Result, Run};
 
 /// Arguments definition of the `dist-archive` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist-archive.md"))]
@@ -11,10 +11,6 @@ pub struct DistArchive {}
 impl Run for DistArchive {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist_build.rs
+++ b/src/subcommand/dist_build.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::{config::Config, Result, Run, SubcommandRun};
+use crate::{config::Config, Result, Run};
 
 /// Arguments definition of the `dist-build` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist-build.md"))]
@@ -47,10 +47,6 @@ pub struct DistBuild {
 impl Run for DistBuild {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist_build_bin.rs
+++ b/src/subcommand/dist_build_bin.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::{cargo, config::Config, Result, Run, SubcommandRun};
+use crate::{cargo, config::Config, Result, Run};
 
 /// Arguments definition of the `dist-build-bin` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist-build-bin.md"))]
@@ -21,10 +21,6 @@ pub struct DistBuildBin {
 impl Run for DistBuildBin {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist_build_completion.rs
+++ b/src/subcommand/dist_build_completion.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use clap_complete::Shell;
 
-use crate::{config::Config, fs::ToRelative, Result, Run, SubcommandRun};
+use crate::{config::Config, fs::ToRelative, Result, Run};
 
 /// Arguments definition of the `dist-build-completion` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist-build-completion.md"))]
@@ -14,10 +14,6 @@ pub struct DistBuildCompletion {}
 impl Run for DistBuildCompletion {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist_build_doc.rs
+++ b/src/subcommand/dist_build_doc.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use eyre::eyre;
 
-use crate::{config::Config, fs::ToRelative, Result, Run, SubcommandRun};
+use crate::{config::Config, fs::ToRelative, Result, Run};
 
 /// Arguments definition of the `dist-build-doc` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist-build-doc.md"))]
@@ -13,10 +13,6 @@ pub struct DistBuildDoc {}
 impl Run for DistBuildDoc {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist_build_license.rs
+++ b/src/subcommand/dist_build_license.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use eyre::eyre;
 
-use crate::{config::Config, fs::ToRelative, Result, Run, SubcommandRun};
+use crate::{config::Config, fs::ToRelative, Result, Run};
 
 /// Arguments definition of the `dist-build-license` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist-build-license.md"))]
@@ -13,10 +13,6 @@ pub struct DistBuildLicense {}
 impl Run for DistBuildLicense {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist_build_man.rs
+++ b/src/subcommand/dist_build_man.rs
@@ -4,7 +4,7 @@ use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use clap_mangen::Man;
 use time::OffsetDateTime;
 
-use crate::{config::Config, Result, Run, SubcommandRun};
+use crate::{config::Config, Result, Run};
 
 /// Arguments definition of the `dist-build-man` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist-build-man.md"))]
@@ -15,10 +15,6 @@ pub struct DistBuildMan {}
 impl Run for DistBuildMan {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist_build_readme.rs
+++ b/src/subcommand/dist_build_readme.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::{config::Config, Result, Run, SubcommandRun};
+use crate::{config::Config, Result, Run};
 
 /// Arguments definition of the `dist-build-readme` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist-build-readme.md"))]
@@ -11,10 +11,6 @@ pub struct DistBuildReadme {}
 impl Run for DistBuildReadme {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/dist_clean.rs
+++ b/src/subcommand/dist_clean.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::{config::Config, Result, Run, SubcommandRun};
+use crate::{config::Config, Result, Run};
 
 /// Arguments definition of the `dist-clean` subcommand.
 #[cfg_attr(doc, doc = include_str!("../../doc/cargo-xtask-dist-clean.md"))]
@@ -11,10 +11,6 @@ pub struct DistClean {}
 impl Run for DistClean {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/doc.rs
+++ b/src/subcommand/doc.rs
@@ -4,7 +4,7 @@ use crate::{
     args::{EnvArgs, PackageArgs},
     config::Config,
     process::CommandExt,
-    Result, Run, SubcommandRun,
+    Result, Run,
 };
 
 /// Arguments definition of the `doc` subcommand.
@@ -25,10 +25,6 @@ pub struct Doc {
 impl Run for Doc {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/docsrs.rs
+++ b/src/subcommand/docsrs.rs
@@ -7,7 +7,7 @@ use crate::{
     args::{EnvArgs, PackageArgs},
     config::Config,
     process::CommandExt,
-    Error, Result, Run, SubcommandRun,
+    Error, Result, Run,
 };
 
 /// Arguments definition of the `docsrs` subcommand.
@@ -34,10 +34,6 @@ pub struct Docsrs {
 impl Run for Docsrs {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/exec.rs
+++ b/src/subcommand/exec.rs
@@ -4,7 +4,7 @@ use crate::{
     args::{EnvArgs, WorkspaceArgs},
     config::Config,
     process::CommandExt,
-    Result, Run, SubcommandRun,
+    Result, Run,
 };
 
 /// Arguments definition of the `exec` subcommand.
@@ -27,10 +27,6 @@ pub struct Exec {
 impl Run for Exec {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/fmt.rs
+++ b/src/subcommand/fmt.rs
@@ -4,7 +4,7 @@ use crate::{
     args::{EnvArgs, PackageArgs},
     config::Config,
     process::CommandExt,
-    Result, Run, SubcommandRun,
+    Result, Run,
 };
 
 /// Arguments definition of the `fmt` subcommand.
@@ -25,10 +25,6 @@ pub struct Fmt {
 impl Run for Fmt {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/sync_rdme.rs
+++ b/src/subcommand/sync_rdme.rs
@@ -4,7 +4,7 @@ use crate::{
     args::{EnvArgs, PackageArgs},
     config::Config,
     process::CommandExt,
-    Result, Run, SubcommandRun,
+    Result, Run,
 };
 
 /// Arguments definition of the `sync-rdme` subcommand.
@@ -25,10 +25,6 @@ pub struct SyncRdme {
 impl Run for SyncRdme {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/test.rs
+++ b/src/subcommand/test.rs
@@ -4,7 +4,7 @@ use crate::{
     args::{EnvArgs, FeatureArgs},
     config::Config,
     process::CommandExt,
-    Result, Run, SubcommandRun,
+    Result, Run,
 };
 
 /// Arguments definition of the `test` subcommand.
@@ -25,10 +25,6 @@ pub struct Test {
 impl Run for Test {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/src/subcommand/udeps.rs
+++ b/src/subcommand/udeps.rs
@@ -4,7 +4,7 @@ use crate::{
     args::{EnvArgs, FeatureArgs},
     config::Config,
     process::CommandExt,
-    Result, Run, SubcommandRun,
+    Result, Run,
 };
 
 /// Arguments definition of the `udeps` subcommand.
@@ -25,10 +25,6 @@ pub struct Udeps {
 impl Run for Udeps {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/xtask/src/lint_doc.rs
+++ b/xtask/src/lint_doc.rs
@@ -4,7 +4,6 @@ use tempfile::TempDir;
 
 use cli_xtask::{
     camino::Utf8Path, clap, config::Config, eyre::eyre, tracing, workspace, Error, Result, Run,
-    SubcommandRun,
 };
 
 /// `lint-doc` subcommand arguments.
@@ -41,10 +40,6 @@ impl LintDoc {
 impl Run for LintDoc {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,6 @@
 use std::any::Any;
 
-use cli_xtask::{
-    clap, config::Config, subcommand::Subcommand as Predefined, Result, Run, SubcommandRun, Xtask,
-};
+use cli_xtask::{clap, config::Config, subcommand::Subcommand as Predefined, Result, Run, Xtask};
 
 mod lint;
 mod lint_doc;
@@ -33,10 +31,6 @@ impl Run for Subcommand {
             Self::XtaskTest(args) => args.run(config)?,
         }
         Ok(())
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {

--- a/xtask/src/tidy_doc.rs
+++ b/xtask/src/tidy_doc.rs
@@ -7,7 +7,7 @@ use std::{
 
 use cli_xtask::{
     camino::Utf8Path, cargo_metadata::Metadata, clap, config::Config, eyre, process::CommandExt,
-    tracing, workspace, Result, Run, SubcommandRun,
+    tracing, workspace, Result, Run,
 };
 
 use crate::util;
@@ -34,10 +34,6 @@ impl TidyDoc {
 impl Run for TidyDoc {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn to_subcommands(&self) -> Option<SubcommandRun> {
-        None
     }
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {


### PR DESCRIPTION
…s()`"

This reverts commit 13d0257c3197f396d850e23cc5a9f866dafffcd3.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cli-xtask/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cli-xtask/blob/HEAD/CHANGELOG.md
-->
