### PR TITLE
release.toml: remove dev-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask"]
 
 [package]
 name = "cli-xtask"
-version = "0.6.1-alpha.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.62.0"
 description = "A collection of utility functions and command line interfaces for cargo-xtask"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See the [Feature flags section](#feature-flags) for more information.
 
 If you want to add the subcommands that are not included in this crate,
 you can add them by creating a new data structure that implements the
-[`clap::Subcommand`](https://docs.rs/clap/4.0.10/clap/derive/trait.Subcommand.html) and [`Run`](https://docs.rs/cli-xtask/latest/cli_xtask/trait.Run.html).
+[`clap::Subcommand`](https://docs.rs/clap/4.0.18/clap/derive/trait.Subcommand.html) and [`Run`](https://docs.rs/cli-xtask/latest/cli_xtask/trait.Run.html).
 See [the documentation of `Xtask`](https://docs.rs/cli-xtask/latest/cli_xtask/command/struct.Xtask.html) for more
 information.
 

--- a/examples/bin-main-with-command/Cargo.lock
+++ b/examples/bin-main-with-command/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "cli-xtask"
-version = "0.6.1-alpha.0"
+version = "0.6.0"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/examples/bin-main/Cargo.lock
+++ b/examples/bin-main/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cli-xtask"
-version = "0.6.1-alpha.0"
+version = "0.6.0"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/release.toml
+++ b/release.toml
@@ -10,4 +10,3 @@ pre-release-replacements = [
   {file = "src/lib.rs", search = "^#!\\[doc\\(html_root_url = \"https://docs.rs/cli-xtask/.*\"\\)\\]$", replace = "#![doc(html_root_url = \"https://docs.rs/cli-xtask/{{version}}\")]", exactly = 1},
 ]
 pre-release-hook = ["cargo", "xtask", "pre-release"]
-dev-version = true


### PR DESCRIPTION
cargo-release removed dev-version support

https://github.com/crate-ci/cargo-release/releases/tag/v0.22.0

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cli-xtask/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cli-xtask/blob/HEAD/CHANGELOG.md
-->
