### PR TITLE
(breaking change) return type of `cargo::build` is now `Result<impl Iteraotr, Error>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+* (breaking change) return type of `cargo::build` is now `Result<impl Iteraotr, Error>`
+
 ## [0.7.1] - 2023-09-23
 
 ## [0.7.0] - 2023-09-17

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -54,7 +54,7 @@ pub fn build<'a>(
     build_options: impl IntoIterator<Item = &'a str>,
     use_cross: bool,
     target_triple: Option<&'a str>,
-) -> Result<impl IntoIterator<Item = Result<Utf8PathBuf>> + 'a> {
+) -> Result<impl Iterator<Item = Result<Utf8PathBuf>> + 'a> {
     let cmd_name = if use_cross { "cross" } else { "cargo" };
     let mut args = vec!["build"];
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cli-xtask/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cli-xtask/blob/HEAD/CHANGELOG.md
-->
