### PR TITLE
Add default impls for Run trait conversion fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+* Add default implementations of the conversion functions on the Run trait to simplify implementations
+
 ## [0.8.0] - 2023-09-24
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,13 +287,28 @@ pub trait Run: Any {
     }
 
     /// Converts the `Box<dyn Run>` to `Box<dyn Any>`.
-    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    fn into_any(self: Box<Self>) -> Box<dyn Any>
+    where
+        Self: Sized,
+    {
+        self
+    }
 
     /// Converts the `&dyn Run` trait object to a concrete type.
-    fn as_any(&self) -> &dyn Any;
+    fn as_any(&self) -> &dyn Any
+    where
+        Self: Sized,
+    {
+        self
+    }
 
     /// Converts the `&dyn Run` trait object to a mutable concrete type.
-    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any
+    where
+        Self: Sized,
+    {
+        self
+    }
 }
 
 /// Subcommands that this command will run.
@@ -343,34 +358,19 @@ mod tests {
         fn run(&self, _config: &config::Config) -> Result<()> {
             Ok(())
         }
-
-        fn into_any(self: Box<Self>) -> Box<dyn Any> {
-            self
-        }
-
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-
-        fn as_any_mut(&mut self) -> &mut dyn Any {
-            self
-        }
     }
 
     #[test]
     fn run_downcast() {
-        let s = S(42);
-        let s = &s as &(dyn Run);
+        let s = &S(42);
         let s = s.as_any().downcast_ref::<S>().unwrap();
         assert_eq!(s.0, 42);
 
-        let mut s = S(42);
-        let s = &mut s as &mut (dyn Run);
+        let s = &mut S(42);
         let s = s.as_any_mut().downcast_mut::<S>().unwrap();
         assert_eq!(s.0, 42);
 
-        let s = S(42);
-        let s = Box::new(s) as Box<dyn Run>;
+        let s = Box::new(S(42));
         let s = s.into_any().downcast::<S>().unwrap();
         assert_eq!(s.0, 42);
     }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,7 +1,4 @@
 //! Command line interfaces for xtask workflows.
-
-use std::any::Any;
-
 use crate::{config::Config, Result, Run};
 
 #[cfg(feature = "subcommand-build")]
@@ -323,18 +320,6 @@ pub enum Subcommand {
 impl Run for Subcommand {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/build.rs
+++ b/src/subcommand/build.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, process::Command};
+use std::process::Command;
 
 use crate::{
     args::{EnvArgs, FeatureArgs},
@@ -25,18 +25,6 @@ pub struct Build {
 impl Run for Build {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/clippy.rs
+++ b/src/subcommand/clippy.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, process::Command};
+use std::process::Command;
 
 use crate::{
     args::{EnvArgs, FeatureArgs},
@@ -25,18 +25,6 @@ pub struct Clippy {
 impl Run for Clippy {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist.rs
+++ b/src/subcommand/dist.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{config::Config, Result, Run};
 
 /// Arguments definition of the `dist` subcommand.
@@ -20,18 +18,6 @@ pub struct Dist {
 impl Run for Dist {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist_archive.rs
+++ b/src/subcommand/dist_archive.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{archive, config::Config, Result, Run};
 
 /// Arguments definition of the `dist-archive` subcommand.
@@ -11,18 +9,6 @@ pub struct DistArchive {}
 impl Run for DistArchive {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist_build.rs
+++ b/src/subcommand/dist_build.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{config::Config, Result, Run};
 
 /// Arguments definition of the `dist-build` subcommand.
@@ -47,18 +45,6 @@ pub struct DistBuild {
 impl Run for DistBuild {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist_build_bin.rs
+++ b/src/subcommand/dist_build_bin.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{cargo, config::Config, Result, Run};
 
 /// Arguments definition of the `dist-build-bin` subcommand.
@@ -21,18 +19,6 @@ pub struct DistBuildBin {
 impl Run for DistBuildBin {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist_build_completion.rs
+++ b/src/subcommand/dist_build_completion.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use clap_complete::Shell;
 
@@ -14,18 +12,6 @@ pub struct DistBuildCompletion {}
 impl Run for DistBuildCompletion {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist_build_doc.rs
+++ b/src/subcommand/dist_build_doc.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use eyre::eyre;
 
 use crate::{config::Config, fs::ToRelative, Result, Run};
@@ -13,18 +11,6 @@ pub struct DistBuildDoc {}
 impl Run for DistBuildDoc {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist_build_license.rs
+++ b/src/subcommand/dist_build_license.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use eyre::eyre;
 
 use crate::{config::Config, fs::ToRelative, Result, Run};
@@ -13,18 +11,6 @@ pub struct DistBuildLicense {}
 impl Run for DistBuildLicense {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist_build_man.rs
+++ b/src/subcommand/dist_build_man.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, iter};
+use std::iter;
 
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use chrono::{Datelike, Utc};
@@ -15,18 +15,6 @@ pub struct DistBuildMan {}
 impl Run for DistBuildMan {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist_build_readme.rs
+++ b/src/subcommand/dist_build_readme.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{config::Config, Result, Run};
 
 /// Arguments definition of the `dist-build-readme` subcommand.
@@ -11,18 +9,6 @@ pub struct DistBuildReadme {}
 impl Run for DistBuildReadme {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/dist_clean.rs
+++ b/src/subcommand/dist_clean.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{config::Config, Result, Run};
 
 /// Arguments definition of the `dist-clean` subcommand.
@@ -11,18 +9,6 @@ pub struct DistClean {}
 impl Run for DistClean {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/doc.rs
+++ b/src/subcommand/doc.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, process::Command};
+use std::process::Command;
 
 use crate::{
     args::{EnvArgs, PackageArgs},
@@ -25,18 +25,6 @@ pub struct Doc {
 impl Run for Doc {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/docsrs.rs
+++ b/src/subcommand/docsrs.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, collections::HashMap, fs, process::Command};
+use std::{collections::HashMap, fs, process::Command};
 
 use cargo_metadata::Package;
 use serde::Deserialize;
@@ -34,18 +34,6 @@ pub struct Docsrs {
 impl Run for Docsrs {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/exec.rs
+++ b/src/subcommand/exec.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, process::Command};
+use std::process::Command;
 
 use crate::{
     args::{EnvArgs, WorkspaceArgs},
@@ -27,18 +27,6 @@ pub struct Exec {
 impl Run for Exec {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/fmt.rs
+++ b/src/subcommand/fmt.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, process::Command};
+use std::process::Command;
 
 use crate::{
     args::{EnvArgs, PackageArgs},
@@ -25,18 +25,6 @@ pub struct Fmt {
 impl Run for Fmt {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/lint.rs
+++ b/src/subcommand/lint.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{args::FeatureArgs, config::Config, Result, Run, SubcommandRun};
 
 /// Arguments definition of the `lint` subcommand.
@@ -19,18 +17,6 @@ impl Run for Lint {
 
     fn to_subcommands(&self) -> Option<SubcommandRun> {
         Some(self.to_subcommands())
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/pre_release.rs
+++ b/src/subcommand/pre_release.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{config::Config, Result, Run, SubcommandRun};
 
 /// Arguments definition of the `pre-release` subcommand.
@@ -15,18 +13,6 @@ impl Run for PreRelease {
 
     fn to_subcommands(&self) -> Option<SubcommandRun> {
         Some(self.to_subcommands())
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/sync_rdme.rs
+++ b/src/subcommand/sync_rdme.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, process::Command};
+use std::process::Command;
 
 use crate::{
     args::{EnvArgs, PackageArgs},
@@ -25,18 +25,6 @@ pub struct SyncRdme {
 impl Run for SyncRdme {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/test.rs
+++ b/src/subcommand/test.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, process::Command};
+use std::process::Command;
 
 use crate::{
     args::{EnvArgs, FeatureArgs},
@@ -25,18 +25,6 @@ pub struct Test {
 impl Run for Test {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/tidy.rs
+++ b/src/subcommand/tidy.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{args::FeatureArgs, config::Config, Result, Run, SubcommandRun};
 
 /// Arguments definition of the `tidy` subcommand.
@@ -28,18 +26,6 @@ impl Run for Tidy {
 
     fn to_subcommands(&self) -> Option<SubcommandRun> {
         Some(self.to_subcommands())
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/src/subcommand/udeps.rs
+++ b/src/subcommand/udeps.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, process::Command};
+use std::process::Command;
 
 use crate::{
     args::{EnvArgs, FeatureArgs},
@@ -25,18 +25,6 @@ pub struct Udeps {
 impl Run for Udeps {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/xtask/src/lint_doc.rs
+++ b/xtask/src/lint_doc.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use tempfile::TempDir;
 
 use cli_xtask::{
@@ -40,17 +38,5 @@ impl LintDoc {
 impl Run for LintDoc {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use cli_xtask::{clap, config::Config, subcommand::Subcommand as Predefined, Result, Run, Xtask};
 
 mod lint;
@@ -31,18 +29,6 @@ impl Run for Subcommand {
             Self::XtaskTest(args) => args.run(config)?,
         }
         Ok(())
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/xtask/src/tidy_doc.rs
+++ b/xtask/src/tidy_doc.rs
@@ -1,5 +1,4 @@
 use std::{
-    any::Any,
     io::{BufWriter, Write},
     iter,
     process::Command,
@@ -34,18 +33,6 @@ impl TidyDoc {
 impl Run for TidyDoc {
     fn run(&self, config: &Config) -> Result<()> {
         self.run(config)
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 


### PR DESCRIPTION
The Run trait has 3 methods to help with converting from a concrete type
to Box<dyn Any>,  &dyn Any and &mut dyn Any. These methods are
implemented for all types that implement Run, but the impls all just
return self. This commit adds default impls for these methods by
changing the trait to require that implementations which call these
methods are sized. This works for every type that currently implements
Run, and allows us to simplify the trait impls.

<!-- Please explain the changes you made -->

PR Note:
I'm not sure if this is desirable (if perhaps there's a need to allow implementations of the trait that are not sized), but this approach certainly dropped a bunch of the boilerplate in my usage of xtask-cli. Taking a quick look at https://github.com/gifnksm/cli-xtask/network/dependents and https://github.com/search?q=cli_xtask+lang%3Arust&type=code doesn't find any implementations of the Run trait in the wild that would be affected by this change.