### PR TITLE
ci: unify GITHUB_TOKEN permissions across workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,6 +9,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   security_audit:
     name: Security Audit
@@ -42,7 +44,6 @@ jobs:
       - cargo-deny
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    permissions: {}
     steps:
       - name: Audit complete
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,9 +5,13 @@ on:
     tags:
       - "v?[0-9]+.[0-9]+.[0-9]+"
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Releasing assets
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   set-matrix:
     runs-on: ubuntu-latest
@@ -257,7 +259,6 @@ jobs:
       - actionlint
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    permissions: {}
     steps:
       - name: CI complete
         run: |

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -6,6 +6,8 @@ on:
     - cron: "0 0 * * 1"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   update-deps:
     name: Update Dependencies


### PR DESCRIPTION
## Summary

Unify `permissions` declarations across all GitHub Actions workflows by:

1. Adding `permissions: {}` at the **workflow level** as a secure default in all workflows
2. Removing redundant `permissions: {}` from individual jobs that were only restating the default
3. Keeping explicit per-job overrides only where elevated permissions are actually needed

Fixes CodeQL alerts: `actions/missing-workflow-permissions`