### PR TITLE
Address nightly clippy lints

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -70,7 +70,9 @@ pub fn build<'a>(
                 TargetKind::Test => args.extend(["--test", target.name.as_str()]),
                 TargetKind::Bench => args.extend(["--bench", target.name.as_str()]),
                 TargetKind::Lib => args.extend(["--lib"]),
-                _ => bail!("unsupported target kind: {}", kind),
+                _ => {
+                    bail!("unsupported target kind: {}", kind);
+                }
             }
         }
     }


### PR DESCRIPTION
```
error: trailing semicolon in macro used in expression position
  --> src/cargo.rs:73:22
   |
73 |                 _ => bail!("unsupported target kind: {}", kind),
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
   = note: this error originates in the macro `bail` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `cli-xtask` (lib) due to 2 previous errors
2026-07-16T01:56:04.487617Z ERROR lint:docsrs: Command for . failed with status exit status: 101
```

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/cli-xtask/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/cli-xtask/blob/HEAD/CHANGELOG.md
-->
